### PR TITLE
Fix typo in the quick move example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Features
         input: (|){["foo"]} (press <M-}> at |)
         output: ({["foo"]}|)
 
-        input: |[foo, bar()] (press (<M-]> at |)
+        input: (|)[foo, bar()] (press (<M-]> at |)
         output: ([foo, bar()]|)
 
 *   Quick jump to closed pair.


### PR DESCRIPTION
The example results in the following output for me:

        input: |[foo, bar()] (press (<M-]> at |)
        output: foo, bar()][

I think you meant:

        input: (|)[foo, bar()] (press (<M-]> at |)
        output: ([foo, bar()]|)