### PR TITLE
Add eventignore to prevent autocommand triggering

### DIFF
--- a/autoload/autopairs/Keybinds.vim
+++ b/autoload/autopairs/Keybinds.vim
@@ -1,5 +1,30 @@
 " Always silent the command
-inoremap <silent> <SID>AutoPairsReturn <cmd>set eventignore+=InsertEnter,InsertLeavePre,InsertLeave<CR><C-R>=autopairs#AutoPairsReturn()<CR><cmd>set eventignore-=InsertEnter,InsertLeavePre,InsertLeave<CR>
+function! autopairs#Keybinds#IgnoreInsertEnter(f) abort
+    let l:pre = "\<C-r>=autopairs#Keybinds#SetEventignore()\<CR>"
+    let l:val = call(function(a:f), a:000)
+    let l:post = "\<C-r>=autopairs#Keybinds#ResetEventignore()\<CR>"
+    return l:pre . l:val . l:post
+endfunction
+
+function! autopairs#Keybinds#IgnoreInsertEnterCmd(cmd) abort
+    call autopairs#Keybinds#SetEventignore()
+    normal a:cmd
+    call autopairs#Keybinds#ResetEventignore()
+    return ''
+endfunction
+
+function! autopairs#Keybinds#SetEventignore()
+    let g:autopairs_oldeventignore = &eventignore
+    set eventignore+=InsertEnter,InsertLeavePre,InsertLeave
+    return ''
+endfunction
+
+function! autopairs#Keybinds#ResetEventignore()
+    let &eventignore = g:autopairs_oldeventignore
+    return ''
+endfunction
+
+inoremap <silent> <SID>AutoPairsReturn <C-r>=autopairs#Keybinds#IgnoreInsertEnter('autopairs#AutoPairsReturn')<cr>
 imap <Plug>AutoPairsReturn <SID>AutoPairsReturn
 
 func! autopairs#Keybinds#ExpandMap(map)
@@ -222,7 +247,7 @@ fun! autopairs#Keybinds#mapKeys()
     if b:AutoPairsMoveExpression != ""
         for key in split(b:AutoPairsMoveCharacter, '\s*')
             let escaped_key = substitute(key, "'", "''", 'g')
-            execute 'inoremap <silent> <buffer> ' . substitute(b:AutoPairsMoveExpression, "%key", key, "") . " <cmd>set eventignore+=InsertEnter,InsertLeavePre,InsertLeave<CR><C-R>=autopairs#AutoPairsMoveCharacter('".escaped_key."')<CR><cmd>set eventignore-=InsertEnter,InsertLeavePre,InsertLeave<CR>"
+            execute 'inoremap <silent> <buffer> ' . substitute(b:AutoPairsMoveExpression, "%key", key, "") . " <C-R>=autopairs#Keybinds#IgnoreInsertEnter('autopairs#AutoPairsMoveCharacter', '".escaped_key."'"
         endfor
     endif
 
@@ -267,6 +292,7 @@ fun! autopairs#Keybinds#mapKeys()
 
     if b:AutoPairsShortcutJump != ''
         " execute 'inoremap <buffer> <silent> ' . b:AutoPairsShortcutJump . ' <cmd>set eventignore+=InsertEnter,InsertLeavePre,InsertLeave<CR><ESC>:call autopairs#AutoPairsJump()<CR>a<cmd>set eventignore-=InsertEnter,InsertLeavePre,InsertLeave<CR>'
+        execute 'inoremap <buffer> <silent> ' . b:AutoPairsShortcutJump . ' <C-r>=autopairs#Keybinds#IgnoreInsertEnterCmd("<ESC>:call autopairs#AutoPairsJump()<CR>a")'
         execute 'inoremap <buffer> <silent> ' . b:AutoPairsShortcutJump . ' <cmd>call autopairs#AutoPairsJump()<CR>'
         execute 'noremap <buffer> <silent> ' . b:AutoPairsShortcutJump . ' :call autopairs#AutoPairsJump()<CR>'
     end

--- a/autoload/autopairs/Keybinds.vim
+++ b/autoload/autopairs/Keybinds.vim
@@ -247,7 +247,7 @@ fun! autopairs#Keybinds#mapKeys()
     if b:AutoPairsMoveExpression != ""
         for key in split(b:AutoPairsMoveCharacter, '\s*')
             let escaped_key = substitute(key, "'", "''", 'g')
-            execute 'inoremap <silent> <buffer> ' . substitute(b:AutoPairsMoveExpression, "%key", key, "") . " <C-R>=autopairs#Keybinds#IgnoreInsertEnter('autopairs#AutoPairsMoveCharacter', '".escaped_key."'"
+            execute 'inoremap <silent> <buffer> ' . substitute(b:AutoPairsMoveExpression, "%key", key, "") . " <C-R>=autopairs#Keybinds#IgnoreInsertEnter('autopairs#AutoPairsMoveCharacter', '".escaped_key."')<CR>"
         endfor
     endif
 

--- a/autoload/autopairs/Keybinds.vim
+++ b/autoload/autopairs/Keybinds.vim
@@ -1,5 +1,5 @@
-" Always silent the command
 function! autopairs#Keybinds#IgnoreInsertEnter(f) abort
+    " TODO: Change this to use <cmd> when support for vim 8.2.19xx is dropped
     let l:pre = "\<C-r>=autopairs#Keybinds#SetEventignore()\<CR>"
     let l:val = call(function(a:f), a:000)
     let l:post = "\<C-r>=autopairs#Keybinds#ResetEventignore()\<CR>"
@@ -14,16 +14,18 @@ function! autopairs#Keybinds#IgnoreInsertEnterCmd(cmd) abort
 endfunction
 
 function! autopairs#Keybinds#SetEventignore()
-    let g:autopairs_oldeventignore = &eventignore
-    set eventignore+=InsertEnter,InsertLeavePre,InsertLeave
+    " TODO: Add InsertLeavePre when we know how to check version correctly on nvim
+    " or when support for vim 8.2.1873 and below is dropped
+    set eventignore+=InsertEnter,InsertLeave
     return ''
 endfunction
 
 function! autopairs#Keybinds#ResetEventignore()
-    let &eventignore = g:autopairs_oldeventignore
+    set eventignore-=InsertEnter,InsertLeave
     return ''
 endfunction
 
+" Always silent the command
 inoremap <silent> <SID>AutoPairsReturn <C-r>=autopairs#Keybinds#IgnoreInsertEnter('autopairs#AutoPairsReturn')<cr>
 imap <Plug>AutoPairsReturn <SID>AutoPairsReturn
 

--- a/autoload/autopairs/Keybinds.vim
+++ b/autoload/autopairs/Keybinds.vim
@@ -1,5 +1,5 @@
 " Always silent the command
-inoremap <silent> <SID>AutoPairsReturn <C-R>=autopairs#AutoPairsReturn()<CR>
+inoremap <silent> <SID>AutoPairsReturn <cmd>set eventignore+=InsertEnter,InsertLeavePre,InsertLeave<CR><C-R>=autopairs#AutoPairsReturn()<CR><cmd>set eventignore-=InsertEnter,InsertLeavePre,InsertLeave<CR>
 imap <Plug>AutoPairsReturn <SID>AutoPairsReturn
 
 func! autopairs#Keybinds#ExpandMap(map)
@@ -222,7 +222,7 @@ fun! autopairs#Keybinds#mapKeys()
     if b:AutoPairsMoveExpression != ""
         for key in split(b:AutoPairsMoveCharacter, '\s*')
             let escaped_key = substitute(key, "'", "''", 'g')
-            execute 'inoremap <silent> <buffer> ' . substitute(b:AutoPairsMoveExpression, "%key", key, "") . " <C-R>=autopairs#AutoPairsMoveCharacter('".escaped_key."')<CR>"
+            execute 'inoremap <silent> <buffer> ' . substitute(b:AutoPairsMoveExpression, "%key", key, "") . " <cmd>set eventignore+=InsertEnter,InsertLeavePre,InsertLeave<CR><C-R>=autopairs#AutoPairsMoveCharacter('".escaped_key."')<CR><cmd>set eventignore-=InsertEnter,InsertLeavePre,InsertLeave<CR>"
         endfor
     endif
 
@@ -266,7 +266,8 @@ fun! autopairs#Keybinds#mapKeys()
     endif
 
     if b:AutoPairsShortcutJump != ''
-        execute 'inoremap <buffer> <silent> ' . b:AutoPairsShortcutJump . ' <ESC>:call autopairs#AutoPairsJump()<CR>a'
+        " execute 'inoremap <buffer> <silent> ' . b:AutoPairsShortcutJump . ' <cmd>set eventignore+=InsertEnter,InsertLeavePre,InsertLeave<CR><ESC>:call autopairs#AutoPairsJump()<CR>a<cmd>set eventignore-=InsertEnter,InsertLeavePre,InsertLeave<CR>'
+        execute 'inoremap <buffer> <silent> ' . b:AutoPairsShortcutJump . ' <cmd>call autopairs#AutoPairsJump()<CR>'
         execute 'noremap <buffer> <silent> ' . b:AutoPairsShortcutJump . ' :call autopairs#AutoPairsJump()<CR>'
     end
 


### PR DESCRIPTION
Fixes #43

Added appropriate eventignore settings wherever <ESC> is used to prevent `Insert{Enter,LeavePre,Leave} autocommands from running. Currently feels a little verbose, would be nice if a better solution can be found