### PR TITLE
Skip initialization if blacklisted

### DIFF
--- a/autoload/autopairs.vim
+++ b/autoload/autopairs.vim
@@ -615,8 +615,7 @@ func! autopairs#AutoPairsTryInit()
         call g:AutoPairsInitHook()
     endif
     if index(g:AutoPairsDirectoryBlacklist, getcwd()) >= 0 || index(g:AutoPairsFiletypeBlacklist, &ft) != -1
-        " TODO: return and make an explicit enable possible
-        let b:autopairs_enabled = 0
+        return
     endif
 
     call autopairs#Variables#_InitBufferVariables()

--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -400,7 +400,7 @@ Core~
 - |g:AutoPairsExperimentalAutocmd| (default: 0)
     Whether or not to use BufWinEnter instead of BufEnter
 - |g:AutoPairsDirectoryBlacklist| (default: [])
-    Directories to disable auto-pairs in
+    Directories to completely disable auto-pairs in
 - |b:autopairs_enabled| ("default": 1)
     Whether or not auto-pairs is enabled in the buffer. Can also be used to
     toggle auto-pairs
@@ -410,8 +410,7 @@ Core~
 - |g:AutoPairsOpenBalanceBlacklist| (has a buffer variant) (default: [])
     Contains a list of characters that don't trigger opening balance checks
 - |g:AutoPairsFiletypeBlacklist| (default: [])
-    Contains filetypes in which |b:autopairs_enabled| is 0 when entering the
-    file.
+    Filetypes to completely disable auto-pairs in
 
 Compat~
 - |g:AutoPairsCompatibleMaps| (default: 1)
@@ -907,14 +906,8 @@ The shortcut to toggle |g:AutoPairsMultilineClose|
 Default: []
 
 Defines a set of directories (checked against |getcwd()|) in which the plugin
-is disabled. This is pretty much a utility around `let b:autopairs_enabled = 0`,
-which means the plugin is toggled in the buffer.
-
-It's disabled by default as this means it's possible to load it after the
-fact, where as a complete block wouldn't allow for manually enabling the
-plugin, if desired.
-
-See also |g:AutoPairsShortcutToggle|
+is completely uninitialized. Note |g:AutoPairsShortcutToggle| cannot enable
+autopairs in these directories.
 
 ------------------------------------------------------------------------------
                                                            *b:autopairs_enabled*
@@ -1316,10 +1309,8 @@ behavior and assume the next character is what you want to wrap.
 
 Default: []
 
-List containing filetypes in which autopairs is disabled by default. Note that
-the keybinds and whatnot are loaded due to how the plugin is built up. This
-may change in a future version. The plugin may be manually enabled in spite of
-this blacklist. See |g:AutoPairsShortcutToggle|
+List containing filetypes in which autopairs is completely uninitialized. Note
+|g:AutoPairsShortcutToggle| cannot enable autopairs in these filetypes.
 
 ------------------------------------------------------------------------------
                                                           *b:AutoPairsJumpRegex*


### PR DESCRIPTION
Skip initialising auto-pairs completely if `g:AutoPairsDirectoryBlacklist`
or `g:AutoPairsFiletypeBlacklist` contains current directory/filetype,
making it impossible to be enabled later on but also avoids issues like
#67.

Closes #67
