### PR TITLE
Doc new g:AutoPairsCompatibleMaps default value 0

### DIFF
--- a/doc/AutoPairs.txt
+++ b/doc/AutoPairs.txt
@@ -1313,7 +1313,7 @@ See also: |\v|, |\V|
                                                      *g:AutoPairsCompatibleMaps*
                                                                            int
 
-Default: 1
+Default: 0
 
 This variable defines whether or not to use backwards-compatible maps.
 


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`8fd8d1e`](https://github.com/LunarWatcher/auto-pairs/pull/73/commits/8fd8d1e852f2f29526e42c611507cebc6d7cfe83) Doc new g:AutoPairsCompatibleMaps default value 0

This was changed in [1].

[1] https://github.com/LunarWatcher/auto-pairs/commit/0fcb708a122d02697b760a7ef52b7ba181bc1f30


<!-- === GH HISTORY FENCE === -->
