### PR TITLE
Use <expr> for common insert maps

### DIFF
--- a/autoload/autopairs.vim
+++ b/autoload/autopairs.vim
@@ -553,7 +553,9 @@ func! autopairs#AutoPairsMap(key, ...)
     if l:explicit && len(maparg(key, "i")) != 0
         return
     endif
-    execute 'inoremap <buffer> <silent> <expr>' key "autopairs#AutoPairsInsert('" .. escaped_key .. "')"
+
+    " Grace: <Cmd> runs a command without leaving insert mode, so we don't need to feed 'i'
+    execute 'inoremap <buffer> <silent>' key "<Cmd>call feedkeys(autopairs#AutoPairsInsert('" .. escaped_key .. "'), 'ni')<CR>"
 endf
 
 func! autopairs#AutoPairsToggle()

--- a/autoload/autopairs.vim
+++ b/autoload/autopairs.vim
@@ -553,7 +553,7 @@ func! autopairs#AutoPairsMap(key, ...)
     if l:explicit && len(maparg(key, "i")) != 0
         return
     endif
-    execute 'inoremap <buffer> <silent>' key "<C-R>=autopairs#AutoPairsInsert('" .. escaped_key .. "')<cr>"
+    execute 'inoremap <buffer> <silent> <expr>' key "autopairs#AutoPairsInsert('" .. escaped_key .. "')"
 endf
 
 func! autopairs#AutoPairsToggle()

--- a/autoload/autopairs/Keybinds.vim
+++ b/autoload/autopairs/Keybinds.vim
@@ -269,7 +269,7 @@ fun! autopairs#Keybinds#mapKeys()
     if b:AutoPairsMapSpace
 
         " <C-]> is required to respect abbreviations
-        execute 'inoremap <buffer> <silent> <SPACE> <C-]><C-R>=autopairs#AutoPairsSpace()<CR>'
+        execute 'inoremap <buffer> <silent> <expr> <SPACE> autopairs#AutoPairsSpace()'
     end
 
     if b:AutoPairsShortcutFastWrap != ''

--- a/autoload/autopairs/Keybinds.vim
+++ b/autoload/autopairs/Keybinds.vim
@@ -263,7 +263,7 @@ fun! autopairs#Keybinds#mapKeys()
     " Still use <buffer> level mapping for <BS> <SPACE>
     if b:AutoPairsMapBS
         " Use <C-R> instead of <expr> for issue #14 sometimes press BS output strange words
-        execute 'inoremap <buffer> <silent> <BS> <C-R>=autopairs#AutoPairsDelete()<CR>'
+        execute 'inoremap <buffer> <silent> <expr> <BS> autopairs#AutoPairsDelete()'
     end
 
     if b:AutoPairsMapSpace

--- a/autoload/autopairs/Keybinds.vim
+++ b/autoload/autopairs/Keybinds.vim
@@ -269,7 +269,7 @@ fun! autopairs#Keybinds#mapKeys()
     if b:AutoPairsMapSpace
 
         " <C-]> is required to respect abbreviations
-        execute 'inoremap <buffer> <silent> <expr> <SPACE> autopairs#AutoPairsSpace()'
+        execute 'inoremap <buffer> <silent> <expr> <SPACE> "<C-]>" .. autopairs#AutoPairsSpace()'
     end
 
     if b:AutoPairsShortcutFastWrap != ''


### PR DESCRIPTION
When using a statusline with mode-based color, the insert maps cause a flicker while they enter command mode for a split second. Using `<expr>` stops this flicker and executes the functions directly.