### PR TITLE
Possible workaround for compatibility hacks depending on plugin load order

### DIFF
--- a/autoload/autopairs/Compat.vim
+++ b/autoload/autopairs/Compat.vim
@@ -1,0 +1,22 @@
+" Plugin compatibility hacks, one function per hack
+" Called from VimEnter autocmd in plugin/autopairs.vim
+
+" https://github.com/mg979/vim-visual-multi
+" NOTE: the typo does NOT stem from auto-pairs; blame vim-visual-multi for
+" that.
+" If it ever changes, this will break. if it does, this is where to look to
+" fix it.
+fun! autopairs#Compat#visualMulti()
+    if exists('g:VM_plugins_compatibilty') || exists('*vm#maps#init')
+        " The test doesn't include any of the `exists`s, because it's pretty damn
+        " obvious that they exist when the plugin creating them is setting it.
+        " No need for those checks when it's set like this.
+        let g:VM_plugins_compatibilty = extend(get(g:, 'VM_plugins_compatibilty', {}), {
+            \'AutoPairs': {
+                    \   'test': { -> 1 },
+                    \   'enable': 'unlet b:autopairs_loaded | call autopairs#AutoPairsTryInit() | let b:autopairs_enabled = 1',
+                    \   'disable': 'let b:autopairs_enabled = 0',
+                    \}
+            \})
+    endif
+endfun

--- a/plugin/autopairs.vim
+++ b/plugin/autopairs.vim
@@ -31,24 +31,8 @@ command! AutoPairsToggle call autopairs#AutoPairsToggle()
 command! AutoPairsDisable let b:autopairs_enabled = 0 | echo "Disabled auto-pairs"
 command! AutoPairsEnable let b:autopairs_enabled = 1 | echo "Enabled auto-pairs"
 
-" Plugin compatibility
-
-" https://github.com/mg979/vim-visual-multi
-" NOTE: the typo does NOT stem from auto-pairs; blame vim-visual-multi for
-" that.
-" If it ever changes, this will break. if it does, this is where to look to
-" fix it.
-if exists('g:VM_plugins_compatibilty') || exists('*vm#maps#init')
-    " The test doesn't include any of the `exists`s, because it's pretty damn
-    " obvious that they exist when the plugin creating them is setting it.
-    " No need for those checks when it's set like this.
-    let g:VM_plugins_compatibilty = extend(get(g:, 'VM_plugins_compatibilty', {}), {
-        \'AutoPairs': {
-                \   'test': { -> 1 },
-                \   'enable': 'unlet b:autopairs_loaded | call autopairs#AutoPairsTryInit() | let b:autopairs_enabled = 1',
-                \   'disable': 'let b:autopairs_enabled = 0',
-                \}
-        \})
-endif
+" Plugin compatibility, see autoload/autopairs/Compat.vim
+autocmd VimEnter *
+    \ call autopairs#Compat#visualMulti()
 
 " vim:sw=4:expandtab


### PR DESCRIPTION
Load plugin compatibility hacks on VimEnter

This is just a suggestion I've quickly put together and seems to work fine.

To avoid issues with plugin load order affecting compatibility hacks (e.g. where the hack checks for a variable or function only defined after the other plugin has been loaded), move compatibility hacks to autoload and call after other plugins have loaded via VimEnter autocmd.