### PR TITLE
Fix: AutoPairsAddLanguagePair doesn't work when filetype is a list

### DIFF
--- a/autoload/autopairs.vim
+++ b/autoload/autopairs.vim
@@ -90,8 +90,9 @@ fun! autopairs#AutoPairsAddPair(pair, ...)
                 call autopairs#AutoPairsAddLanguagePair(a:pair, filetypes)
                 return
             elseif type(filetypes) == v:t_list
+                let saved_pair = copy(a:pair)
                 for ft in filetypes
-                    call autopairs#AutoPairsAddLanguagePair(a:pair, ft)
+                    call autopairs#AutoPairsAddLanguagePair(copy(saved_pair), ft)
                 endfor
                 return
             else


### PR DESCRIPTION
```vimscript
vim9script

call autopairs#Variables#InitVariables()

g:AutoPairs = autopairs#AutoPairsDefine([
  {"open": '\v(enum|class|struct).{-} (: (.{-}[ ,])+)? ?\{', 'close': '};', 'mapopen': '{', 'filetype': ['cpp', 'c'], 'regex': 1},
])
```
This doesn't work because `a:pair["open"]` is removed after the first `cpp` iteration.

https://github.com/LunarWatcher/auto-pairs/blob/fe5c833220661071c2c81ee95f7636ff1923b8d9/autoload/autopairs.vim#L45-L45

```
Error detected while processing function <lambda>3[11]..script /home/benyip/.vim/rc/auto-pairs.vim[13]..function autopairs#AutoPairsDefine[15]..autopairs#AutoPairsAddPairs[3]..autopairs#AutoPairsAddPair[36]..autopairs#AutoPairsAddLanguag
ePair:
line    2:
Invalid pair: missing open and/or close
```

This PR copies `a:pair` before is passed to `AutoPairsAddLanguagePair`. Maybe it's not the best way to fix it.